### PR TITLE
Add 3 ICML 2026 papers and 3 preprints for Jan-Willem van de Meent

### DIFF
--- a/_bibliography/AMLab.bib
+++ b/_bibliography/AMLab.bib
@@ -1,3 +1,63 @@
+@article{curvo2026follow,
+  title = {Follow the Mean: Reference-Guided Flow Matching},
+  author = {Curvo, Pedro M. P. and Zhdanov, Maksim and Eijkelboom, Floor and {van de Meent}, Jan-Willem},
+  year = {2026},
+  journal = {arXiv preprint},
+  abbr = {arXiv},
+  html = {https://arxiv.org/abs/2605.10302},
+  pdf = {https://arxiv.org/pdf/2605.10302}
+}
+
+@article{esteban2026kernel,
+  title = {Kernel-Gradient Drifting Models},
+  author = {Esteban-Casadevall, Maria and Carrasco-Pollo, Jorge and Welling, Max and {van de Meent}, Jan-Willem and Bekkers, Erik J. and Eijkelboom, Floor},
+  year = {2026},
+  journal = {arXiv preprint},
+  abbr = {arXiv},
+  html = {https://arxiv.org/abs/2605.10727},
+  pdf = {https://arxiv.org/pdf/2605.10727}
+}
+
+@article{hadziveljkovic2026crystalite,
+  title = {Crystalite: A Lightweight Transformer for Efficient Crystal Modeling},
+  author = {{Had\v{z}i Veljkovi\'{c}}, Tin and Rosenthal, Joshua and Lon\v{c}ari\'{c}, Ivor and {van de Meent}, Jan-Willem},
+  year = {2026},
+  journal = {arXiv preprint},
+  abbr = {arXiv},
+  html = {https://arxiv.org/abs/2604.02270},
+  pdf = {https://arxiv.org/pdf/2604.02270}
+}
+
+@inproceedings{roos2026categorical,
+  title = {Categorical Flow Maps},
+  author = {Roos, Daan and Davis, Oscar and Eijkelboom, Floor and Bronstein, Michael and Welling, Max and Ceylan, {\.I}smail {\.I}lkan and Ambrogioni, Luca and {van de Meent}, Jan-Willem},
+  booktitle = {International Conference on Machine Learning},
+  year = {2026},
+  abbr = {ICML},
+  html = {https://arxiv.org/abs/2602.12233},
+  pdf = {https://arxiv.org/pdf/2602.12233}
+}
+
+@inproceedings{zhdanov2026mosaic,
+  title = {(Sparse) Attention to the Details: Preserving Spectral Fidelity in {ML}-based Weather Forecasting Models},
+  author = {Zhdanov, Maksim and Lucic, Ana and Welling, Max and {van de Meent}, Jan-Willem},
+  booktitle = {International Conference on Machine Learning},
+  year = {2026},
+  abbr = {ICML},
+  html = {https://arxiv.org/abs/2604.16429},
+  pdf = {https://arxiv.org/pdf/2604.16429}
+}
+
+@inproceedings{chen2026discovering,
+  title = {Discovering Symmetry Groups with Flow Matching},
+  author = {Chen, Yuxuan and Park, Jung Yeon and Eijkelboom, Floor and Yang, Jianke and {van de Meent}, Jan-Willem and Wong, Lawson L. S. and Walters, Robin},
+  booktitle = {International Conference on Machine Learning},
+  year = {2026},
+  abbr = {ICML},
+  html = {https://arxiv.org/abs/2512.20043},
+  pdf = {https://arxiv.org/pdf/2512.20043}
+}
+
 @inproceedings{macfarlane2026gradient,
   title={Gradient-Based Program Synthesis with Neurally Interpreted Languages},
   author={Macfarlane, Matthew and Bonnet, Cl\'{e}ment and van Hoof, Herke and Lelis, Levi},

--- a/_bibliography/JanWillemVanDeMeent.bib
+++ b/_bibliography/JanWillemVanDeMeent.bib
@@ -1,11 +1,61 @@
-@article{roos2026categorical,
-  title = {Categorical Flow Maps},
-  author = {Roos, Daan and Davis, Oscar and Eijkelboom, Floor and Bronstein, Michael and Welling, Max and Ceylan, {\.I}smail {\.I}lkan and Ambrogioni, Luca and {van de Meent}, Jan-Willem},
+@article{curvo2026follow,
+  title = {Follow the Mean: Reference-Guided Flow Matching},
+  author = {Curvo, Pedro M. P. and Zhdanov, Maksim and Eijkelboom, Floor and {van de Meent}, Jan-Willem},
   year = {2026},
   journal = {arXiv preprint},
   abbr = {arXiv},
+  html = {https://arxiv.org/abs/2605.10302},
+  pdf = {https://arxiv.org/pdf/2605.10302}
+}
+
+@article{esteban2026kernel,
+  title = {Kernel-Gradient Drifting Models},
+  author = {Esteban-Casadevall, Maria and Carrasco-Pollo, Jorge and Welling, Max and {van de Meent}, Jan-Willem and Bekkers, Erik J. and Eijkelboom, Floor},
+  year = {2026},
+  journal = {arXiv preprint},
+  abbr = {arXiv},
+  html = {https://arxiv.org/abs/2605.10727},
+  pdf = {https://arxiv.org/pdf/2605.10727}
+}
+
+@article{hadziveljkovic2026crystalite,
+  title = {Crystalite: A Lightweight Transformer for Efficient Crystal Modeling},
+  author = {{Had\v{z}i Veljkovi\'{c}}, Tin and Rosenthal, Joshua and Lon\v{c}ari\'{c}, Ivor and {van de Meent}, Jan-Willem},
+  year = {2026},
+  journal = {arXiv preprint},
+  abbr = {arXiv},
+  html = {https://arxiv.org/abs/2604.02270},
+  pdf = {https://arxiv.org/pdf/2604.02270}
+}
+
+@inproceedings{roos2026categorical,
+  title = {Categorical Flow Maps},
+  author = {Roos, Daan and Davis, Oscar and Eijkelboom, Floor and Bronstein, Michael and Welling, Max and Ceylan, {\.I}smail {\.I}lkan and Ambrogioni, Luca and {van de Meent}, Jan-Willem},
+  booktitle = {International Conference on Machine Learning},
+  year = {2026},
+  abbr = {ICML},
   html = {https://arxiv.org/abs/2602.12233},
   pdf = {https://arxiv.org/pdf/2602.12233}
+}
+
+@inproceedings{zhdanov2026mosaic,
+  title = {(Sparse) Attention to the Details: Preserving Spectral Fidelity in {ML}-based Weather Forecasting Models},
+  author = {Zhdanov, Maksim and Lucic, Ana and Welling, Max and {van de Meent}, Jan-Willem},
+  booktitle = {International Conference on Machine Learning},
+  year = {2026},
+  abbr = {ICML},
+  html = {https://arxiv.org/abs/2604.16429},
+  pdf = {https://arxiv.org/pdf/2604.16429}
+}
+
+@inproceedings{chen2026discovering,
+  title = {Discovering Symmetry Groups with Flow Matching},
+  author = {Chen, Yuxuan and Park, Jung Yeon and Eijkelboom, Floor and Yang, Jianke and {van de Meent}, Jan-Willem and Wong, Lawson L. S. and Walters, Robin},
+  booktitle = {International Conference on Machine Learning},
+  year = {2026},
+  abbr = {ICML},
+  html = {https://arxiv.org/abs/2512.20043},
+  pdf = {https://arxiv.org/pdf/2512.20043}
 }
 
 @inproceedings{matisan2026purrception,
@@ -48,15 +98,6 @@
   pdf = {https://arxiv.org/pdf/2512.01738}
 }
 
-@article{park2025liegroups,
-  title = {Discovering Lie Groups with Flow Matching},
-  author = {Park, Jung Yeon and Chen, Yuxuan and Eijkelboom, Floor and {van de Meent}, Jan-Willem and Wong, Lawson L. S. and Walters, Robin},
-  year = {2025},
-  journal = {arXiv preprint},
-  abbr = {arXiv},
-  html = {https://arxiv.org/abs/2512.20043},
-  pdf = {https://arxiv.org/pdf/2512.20043}
-}
 
 @article{farnoosh2020deep,
   title = {Deep {{Markov Spatio}}-{{Temporal Factorization}}},


### PR DESCRIPTION
## Summary

- Promote 3 papers to ICML 2026 in `JanWillemVanDeMeent.bib` and `AMLab.bib`: Categorical Flow Maps, Discovering Symmetry Groups with Flow Matching (also fixes title/authors from earlier preprint entry), and (Sparse) Attention to the Details
- Add 3 new preprints: Follow the Mean, Kernel-Gradient Drifting Models, Crystalite

🤖 Generated with [Claude Code](https://claude.com/claude-code)